### PR TITLE
Format document as ~S sigil

### DIFF
--- a/lib/apq.ex
+++ b/lib/apq.ex
@@ -17,22 +17,21 @@ defmodule Apq do
               |> Map.from_struct()
               |> Map.to_list(),
             string != nil do
-          concat(Atom.to_string(key) <> ": ", render_value(string))
+          if key == :document do
+            concat([
+              Atom.to_string(key) <> ": ~S'''",
+              break("\n"),
+              string,
+              break("\n"),
+              "'''",
+              break("\n")
+            ])
+          else
+            concat(Atom.to_string(key) <> ": ", inspect(string))
+          end
         end
 
       container_doc("#Apq.Document<", list, ">", opts, fn str, _ -> str end)
-    end
-
-    defp render_value(val) when is_atom(val) do
-      ":" <> Atom.to_string(val)
-    end
-
-    defp render_value(val) when is_binary(val) do
-      concat([break("\n"), inspect(val)])
-    end
-
-    defp render_value(val) do
-      inspect(val)
     end
   end
 end


### PR DESCRIPTION
Related to #92.
Example of inspection of the document from tests
```
#Apq.Document<action: :apq_stored, digest: "3494de98a73e2c9cda2a6ae623a94e8a52ebaea4b6017b4ab6b411c8d5cb9d55", document: ~S'''
query FooQuery($id: ID!) {
  item(id: $id) {
    name
  }
}

'''
>

```